### PR TITLE
feat: smoke tests, RHSM secret fix, debug packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Push Container Image
+name: Build, Test, and Push Container Image
 
 on:
   push:
@@ -15,23 +15,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Quay.io
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Extract metadata
         id: meta
@@ -42,19 +31,115 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=
 
-      - name: Build and push
+      - name: Create RHSM secret files
+        run: |
+          echo "${{ secrets.RHSM_ACTIVATION_KEY }}" > /tmp/RHSM_ACTIVATION_KEY
+          echo "${{ secrets.RHSM_ORG_ID }}" > /tmp/RHSM_ORG_ID
+
+      - name: Build image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Containerfile
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            RHSM_ACTIVATION_KEY=${{ secrets.RHSM_ACTIVATION_KEY }}
-            RHSM_ORG_ID=${{ secrets.RHSM_ORG_ID }}
+          secrets: |
+            RHSM_ACTIVATION_KEY=/tmp/RHSM_ACTIVATION_KEY
+            RHSM_ORG_ID=/tmp/RHSM_ORG_ID
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Save image as tarball
+        run: docker save ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest -o /tmp/image.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-image
+          path: /tmp/image.tar
+          retention-days: 1
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: container-image
+          path: /tmp
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq podman
+
+      - name: Load image
+        run: podman load -i /tmp/image.tar
+
+      - name: Start container
+        run: |
+          podman run -d --name test-container \
+            --systemd=always \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Wait for systemd services
+        run: |
+          echo "Waiting for services to start..."
+          for i in $(seq 1 30); do
+            if podman exec test-container systemctl is-active httpd >/dev/null 2>&1 && \
+               podman exec test-container systemctl is-active mariadb >/dev/null 2>&1; then
+              echo "Services are up after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run smoke tests
+        run: |
+          podman cp tests/smoke-test.sh test-container:/tmp/smoke-test.sh
+          podman exec test-container chmod +x /tmp/smoke-test.sh
+          podman exec test-container /tmp/smoke-test.sh
+
+      - name: Cleanup
+        if: always()
+        run: podman rm -f test-container
+
+  push:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: container-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load -i /tmp/image.tar
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Push image
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          # Push SHA tag if available
+          SHA_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$(echo ${{ github.sha }} | cut -c1-7)"
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest "$SHA_TAG" || true
+          docker push "$SHA_TAG" || true
 
   validate-constitution:
     name: Constitution Validation

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,7 +1,7 @@
 # ubi10-httpd-php Constitution
 
-> **Version:** 1.0.0
-> **Ratified:** 2026-03-03
+> **Version:** 1.1.0
+> **Ratified:** 2026-03-10
 > **Status:** Active
 > **Inherits:** [crunchtools/constitution](https://github.com/crunchtools/constitution) v1.0.0
 > **Profile:** Container Image
@@ -28,7 +28,7 @@ Published to `quay.io/crunchtools/ubi10-httpd-php`.
 
 ## RHSM Registration
 
-Uses build-arg based subscription-manager registration to access RHEL repos for packages not available in UBI.
+Uses `--mount=type=secret` for subscription-manager registration to access RHEL repos for packages not available in UBI. Register, install, and unregister happen in a single `RUN` layer so secrets are never cached in intermediate layers.
 
 ## Containerfile Conventions
 
@@ -43,14 +43,17 @@ Uses build-arg based subscription-manager registration to access RHEL repos for 
 
 ## Packages Installed
 
-httpd, mariadb-server, mariadb, php, php-mysqlnd, php-json, php-xml, php-mbstring, php-intl, php-gd, php-opcache, php-pecl-apcu, cronie, procps-ng, diffutils
+httpd, mariadb-server, mariadb, php, php-mysqlnd, php-json, php-xml, php-mbstring, php-intl, php-gd, php-opcache, php-pecl-apcu, cronie, procps-ng, diffutils, iputils, bind-utils, net-tools, less
 
 ## Testing
 
 - **Build test**: CI builds the image on every push to main/master
+- **Smoke tests**: Service health (httpd, mariadb), PHP functional (phpinfo via Apache), package integrity (rpm -q for all packages)
 - **Security scan**: Recommended (not yet implemented)
 
 ## Quality Gates
 
 1. Build — CI builds the Containerfile successfully
-2. Weekly rebuild — cron job picks up base image updates every Monday 6 AM UTC
+2. Test — smoke tests pass (services up, PHP works, packages present)
+3. Push — image published only after tests pass
+4. Weekly rebuild — cron job picks up base image updates every Monday 6 AM UTC

--- a/.specify/specs/001-smoke-tests/spec.md
+++ b/.specify/specs/001-smoke-tests/spec.md
@@ -1,7 +1,7 @@
 # Specification: Smoke Tests, Service Tests, and Troubleshooting Packages
 
 > **Spec ID:** 001-smoke-tests
-> **Status:** Draft
+> **Status:** Implemented
 > **Version:** 0.1.0
 > **Author:** Scott McCarty
 > **Date:** 2026-03-10

--- a/Containerfile
+++ b/Containerfile
@@ -3,32 +3,35 @@ FROM registry.access.redhat.com/ubi10/ubi-init:latest
 LABEL maintainer="fatherlinux <scott.mccarty@crunchtools.com>"
 LABEL description="UBI 10 base image with Apache httpd, MariaDB, and PHP 8.3 for WordPress hosting"
 
-# Register with RHSM to access full RHEL repos
-ARG RHSM_ACTIVATION_KEY
-ARG RHSM_ORG_ID
-RUN subscription-manager register --activationkey="$RHSM_ACTIVATION_KEY" --org="$RHSM_ORG_ID"
-
-# Install packages - PHP 8.3 is default in RHEL 10
-RUN dnf install -y \
-    httpd \
-    mariadb-server \
-    mariadb \
-    php \
-    php-mysqlnd \
-    php-json \
-    php-xml \
-    php-mbstring \
-    php-intl \
-    php-gd \
-    php-opcache \
-    php-pecl-apcu \
-    cronie \
-    procps-ng \
-    diffutils \
-    && dnf clean all
-
-# Unregister to avoid leaking entitlements in the image
-RUN subscription-manager unregister
+# Register with RHSM, install packages, unregister — single layer so secrets
+# are never cached in intermediate layers
+RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
+    --mount=type=secret,id=RHSM_ORG_ID \
+    subscription-manager register \
+      --activationkey="$(cat /run/secrets/RHSM_ACTIVATION_KEY)" \
+      --org="$(cat /run/secrets/RHSM_ORG_ID)" \
+    && dnf install -y \
+      httpd \
+      mariadb-server \
+      mariadb \
+      php \
+      php-mysqlnd \
+      php-json \
+      php-xml \
+      php-mbstring \
+      php-intl \
+      php-gd \
+      php-opcache \
+      php-pecl-apcu \
+      cronie \
+      procps-ng \
+      diffutils \
+      iputils \
+      bind-utils \
+      net-tools \
+      less \
+    && dnf clean all \
+    && subscription-manager unregister
 
 # Enable services
 RUN systemctl enable httpd mariadb
@@ -40,4 +43,3 @@ RUN systemctl mask systemd-remount-fs.service \
 
 STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/sbin/init"]
-CMD ["/sbin/init"]

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# smoke-test.sh — smoke tests for ubi10-httpd-php container image
+# Run inside a running container started with --systemd=always
+# Exit 0 = all pass, Exit 1 = one or more failures
+
+set -uo pipefail
+
+FAILURES=0
+TESTS=0
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $1"
+}
+
+# ---------- Service Health ----------
+echo "=== Service Health ==="
+
+if systemctl is-active httpd >/dev/null 2>&1; then
+    pass "httpd is active"
+else
+    fail "httpd is not active"
+fi
+
+if systemctl is-active mariadb >/dev/null 2>&1; then
+    pass "mariadb is active"
+else
+    fail "mariadb is not active"
+fi
+
+# ---------- Functional Tests ----------
+echo "=== Functional Tests ==="
+
+# PHP via Apache — create temp phpinfo page, test, clean up
+TEST_PHP="/var/www/html/test.php"
+echo '<?php phpinfo(); ?>' > "$TEST_PHP"
+
+RESPONSE=$(curl -sf http://localhost/test.php 2>/dev/null || true)
+if echo "$RESPONSE" | grep -q "PHP Version"; then
+    pass "PHP via Apache returns phpinfo"
+else
+    fail "PHP via Apache did not return phpinfo"
+fi
+
+rm -f "$TEST_PHP"
+
+# PHP modules
+echo "--- PHP Modules ---"
+PHP_MODULES=$(php -m 2>/dev/null)
+for mod in mysqlnd mbstring xml intl gd; do
+    if echo "$PHP_MODULES" | grep -qi "^${mod}$"; then
+        pass "PHP module: $mod"
+    else
+        fail "PHP module missing: $mod"
+    fi
+done
+
+# ---------- Package Integrity ----------
+echo "=== Package Integrity ==="
+
+PACKAGES=(
+    httpd
+    mariadb-server
+    mariadb
+    php
+    php-mysqlnd
+    php-json
+    php-xml
+    php-mbstring
+    php-intl
+    php-gd
+    php-opcache
+    php-pecl-apcu
+    cronie
+    procps-ng
+    diffutils
+    iputils
+    bind-utils
+    net-tools
+    less
+)
+
+for pkg in "${PACKAGES[@]}"; do
+    if rpm -q "$pkg" >/dev/null 2>&1; then
+        pass "package: $pkg"
+    else
+        fail "package missing: $pkg"
+    fi
+done
+
+# ---------- Summary ----------
+echo ""
+echo "=== Results: $((TESTS - FAILURES))/$TESTS passed ==="
+
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES test(s) failed"
+    exit 1
+fi
+
+echo "All tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Implements [spec 001-smoke-tests](https://github.com/crunchtools/ubi10-httpd-php/blob/master/.specify/specs/001-smoke-tests/spec.md). Closes #1.

- **Containerfile**: Migrate RHSM from `ARG` to `--mount=type=secret`, consolidate into single `RUN` layer, add 4 troubleshooting packages (`iputils`, `bind-utils`, `net-tools`, `less`), remove redundant `CMD`
- **CI pipeline**: Restructure into `build → test → push` chain — broken images never reach the registry
- **Smoke tests**: `tests/smoke-test.sh` — service health (httpd, mariadb), PHP functional (phpinfo via Apache), PHP module verification, package integrity (`rpm -q` for all 19 packages)
- **Constitution**: Bumped to v1.1.0 — updated RHSM Registration, Testing, and Quality Gates sections

## Test plan

- [ ] CI build job succeeds with `--mount=type=secret` (replaces `build-args`)
- [ ] Test job starts container with `--systemd=always`, services come up
- [ ] All 26 smoke tests pass (2 service + 1 PHP functional + 5 PHP modules + 19 packages = 27, but who's counting)
- [ ] Push job only runs after test job passes
- [ ] Constitution validation passes
- [ ] Verify image works on lotor with existing WordPress bind mounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)