### PR TITLE
fix: buildx secrets syntax for RHSM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            RHSM_ACTIVATION_KEY=/tmp/RHSM_ACTIVATION_KEY
-            RHSM_ORG_ID=/tmp/RHSM_ORG_ID
+            id=RHSM_ACTIVATION_KEY,src=/tmp/RHSM_ACTIVATION_KEY
+            id=RHSM_ORG_ID,src=/tmp/RHSM_ORG_ID
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

- Fix `secrets` parameter in `docker/build-push-action` — the `KEY=/path` format passes the path as a literal string value, not as a file source
- Correct syntax is `id=KEY,src=/path` which reads the file contents

The build job from #4 failed because `subscription-manager register --org` received the literal string `/tmp/RHSM_ORG_ID` instead of the actual org ID.

## Test plan

- [ ] Build job passes — RHSM registration succeeds with file-based secrets
- [ ] Test job runs smoke tests
- [ ] Push job delivers image to Quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)