### PR TITLE
fix: use secret-files for buildx file-based secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,9 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          secrets: |
-            id=RHSM_ACTIVATION_KEY,src=/tmp/RHSM_ACTIVATION_KEY
-            id=RHSM_ORG_ID,src=/tmp/RHSM_ORG_ID
+          secret-files: |
+            RHSM_ACTIVATION_KEY=/tmp/RHSM_ACTIVATION_KEY
+            RHSM_ORG_ID=/tmp/RHSM_ORG_ID
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary

- `docker/build-push-action` has two separate inputs: `secrets` (inline strings) and `secret-files` (file paths)
- PR #5 used `secrets` with `id=,src=` syntax which buildx parsed as `id=id` for both — secrets never mounted
- This PR switches to `secret-files` which is purpose-built for `KEY=/path/to/file` mapping

## Test plan

- [ ] Build job passes — secrets mounted at `/run/secrets/RHSM_ACTIVATION_KEY` and `/run/secrets/RHSM_ORG_ID`
- [ ] Full pipeline completes: build → test → push

🤖 Generated with [Claude Code](https://claude.com/claude-code)