### PR TITLE
fix: remove php-json, add curl retry for httpd

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -43,7 +43,7 @@ Uses `--mount=type=secret` for subscription-manager registration to access RHEL 
 
 ## Packages Installed
 
-httpd, mariadb-server, mariadb, php, php-mysqlnd, php-json, php-xml, php-mbstring, php-intl, php-gd, php-opcache, php-pecl-apcu, cronie, procps-ng, diffutils, iputils, bind-utils, net-tools, less
+httpd, mariadb-server, mariadb, php, php-mysqlnd, php-xml, php-mbstring, php-intl, php-gd, php-opcache, php-pecl-apcu, cronie, procps-ng, diffutils, iputils, bind-utils, net-tools, less
 
 ## Testing
 

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,6 @@ RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
       mariadb \
       php \
       php-mysqlnd \
-      php-json \
       php-xml \
       php-mbstring \
       php-intl \

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -41,7 +41,14 @@ echo "=== Functional Tests ==="
 TEST_PHP="/var/www/html/test.php"
 echo '<?php phpinfo(); ?>' > "$TEST_PHP"
 
-RESPONSE=$(curl -sf http://localhost/test.php 2>/dev/null || true)
+RESPONSE=""
+for i in $(seq 1 10); do
+    RESPONSE=$(curl -sf http://localhost/test.php 2>/dev/null || true)
+    if echo "$RESPONSE" | grep -q "PHP Version"; then
+        break
+    fi
+    sleep 1
+done
 if echo "$RESPONSE" | grep -q "PHP Version"; then
     pass "PHP via Apache returns phpinfo"
 else
@@ -70,7 +77,6 @@ PACKAGES=(
     mariadb
     php
     php-mysqlnd
-    php-json
     php-xml
     php-mbstring
     php-intl


### PR DESCRIPTION
## Summary

Fixes the two test failures from the 001-smoke-tests pipeline:

- **`php-json` removed**: In PHP 8.0+, JSON is compiled into core — no separate package exists in RHEL 10. Removed from Containerfile, smoke test package list, and constitution.
- **curl retry loop**: `systemctl is-active httpd` returns before httpd has fully bound to the socket. Added retry loop (up to 10 attempts, 1s apart) so the PHP functional test waits for httpd to actually serve requests.

## Test plan

- [ ] Build succeeds (no `php-json` means no missing package error from dnf)
- [ ] All 25 smoke tests pass (was 27, minus 2 removed: php-json package check removed, and the curl test now retries)
- [ ] Image pushes to Quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)