### PR TITLE
fix: enable php-fpm for PHP processing via Apache

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -36,7 +36,7 @@ Uses `--mount=type=secret` for subscription-manager registration to access RHEL 
 - Required LABELs: `maintainer`, `description`
 - `dnf install -y` followed by `dnf clean all`
 - `subscription-manager unregister` after package installation
-- systemd services enabled: httpd, mariadb
+- systemd services enabled: httpd, mariadb, php-fpm
 - systemd services masked: systemd-remount-fs, systemd-update-done, systemd-udev-trigger
 - `STOPSIGNAL SIGRTMIN+3` for proper systemd shutdown
 - `ENTRYPOINT ["/sbin/init"]`

--- a/Containerfile
+++ b/Containerfile
@@ -33,7 +33,7 @@ RUN --mount=type=secret,id=RHSM_ACTIVATION_KEY \
     && subscription-manager unregister
 
 # Enable services
-RUN systemctl enable httpd mariadb
+RUN systemctl enable httpd mariadb php-fpm
 
 # Disable unnecessary systemd services for container
 RUN systemctl mask systemd-remount-fs.service \

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -34,6 +34,12 @@ else
     fail "mariadb is not active"
 fi
 
+if systemctl is-active php-fpm >/dev/null 2>&1; then
+    pass "php-fpm is active"
+else
+    fail "php-fpm is not active"
+fi
+
 # ---------- Functional Tests ----------
 echo "=== Functional Tests ==="
 


### PR DESCRIPTION
## Summary

Root cause of the PHP via Apache test failure: `php-fpm` was never enabled as a systemd service.

In RHEL 10, PHP 8.3 uses php-fpm as a separate service. Apache proxies `.php` requests to php-fpm via `/etc/httpd/conf.d/php.conf`, but without php-fpm running, httpd has nothing to proxy to. This is why the existing WordPress deployments work — they mount volumes with data where php-fpm is already configured and running via `--systemd=always`.

- `systemctl enable php-fpm` added to Containerfile
- `php-fpm` health check added to smoke tests
- Constitution updated to list php-fpm in enabled services

## Test plan

- [ ] All 27 smoke tests pass (3 service health + 1 PHP functional + 5 PHP modules + 18 packages)
- [ ] Image pushes to Quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)