### PR TITLE
fix: use PHP file_get_contents instead of curl for HTTP test

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -49,7 +49,7 @@ echo '<?php phpinfo(); ?>' > "$TEST_PHP"
 
 RESPONSE=""
 for i in $(seq 1 10); do
-    RESPONSE=$(curl -sf http://localhost/test.php 2>/dev/null || true)
+    RESPONSE=$(php -r "echo @file_get_contents('http://localhost/test.php') ?: '';" 2>/dev/null || true)
     if echo "$RESPONSE" | grep -q "PHP Version"; then
         break
     fi


### PR DESCRIPTION
## Summary

Replace `curl -sf` with `php -r "file_get_contents('http://localhost/test.php')"` for the PHP via Apache functional test.

`curl` may not be installed in the ubi-init base image (or may be `curl-minimal` with different behavior). PHP's `file_get_contents()` is guaranteed available since PHP is a core package, and it still tests the full Apache → php-fpm → PHP processing pipeline.

## Test plan

- [ ] PHP via Apache test passes
- [ ] All 27 smoke tests pass
- [ ] Image pushes to Quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)