### PR TITLE
fix: use tempfile for PHP response instead of shell variable

### DIFF
--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -47,36 +47,23 @@ echo "=== Functional Tests ==="
 TEST_PHP="/var/www/html/test.php"
 echo '<?php phpinfo(); ?>' > "$TEST_PHP"
 
-# Debug: show httpd config, php-fpm socket, and test file
-echo "--- Debug: PHP test diagnostics ---"
-ls -la "$TEST_PHP" 2>&1 || true
-echo "php-fpm listen config:"
-grep -r "^listen" /etc/php-fpm.d/ 2>/dev/null || true
-echo "httpd php proxy config:"
-cat /etc/httpd/conf.d/php.conf 2>/dev/null || echo "NO php.conf found"
-echo "httpd listening ports:"
-ss -tlnp 2>/dev/null | grep httpd || true
-echo "php-fpm socket:"
-ls -la /run/php-fpm/ 2>/dev/null || true
-echo "--- End debug ---"
-
-RESPONSE=""
+RESPONSE_FILE=$(mktemp)
+PHP_OK=false
 for i in $(seq 1 10); do
-    RESPONSE=$(php -r "echo @file_get_contents('http://localhost/test.php') ?: '';" 2>&1 || true)
-    if echo "$RESPONSE" | grep -q "PHP Version"; then
+    php -r "echo @file_get_contents('http://localhost/test.php') ?: '';" > "$RESPONSE_FILE" 2>/dev/null || true
+    if grep -q "phpinfo" "$RESPONSE_FILE"; then
+        PHP_OK=true
         break
     fi
     sleep 1
 done
-if echo "$RESPONSE" | grep -q "PHP Version"; then
+if $PHP_OK; then
     pass "PHP via Apache returns phpinfo"
 else
-    echo "  DEBUG: response length=${#RESPONSE}, first 200 chars:"
-    echo "  ${RESPONSE:0:200}"
     fail "PHP via Apache did not return phpinfo"
 fi
 
-rm -f "$TEST_PHP"
+rm -f "$TEST_PHP" "$RESPONSE_FILE"
 
 # PHP modules
 echo "--- PHP Modules ---"


### PR DESCRIPTION
## Summary

Root cause found: the phpinfo response is **82,876 bytes** of valid HTML — PHP via Apache works perfectly. The test failed because storing ~83KB in a shell variable and piping it through `echo "$VAR" | grep` silently fails.

Fix: write the response to a tempfile with `php -r ... > "$RESPONSE_FILE"` and `grep` the file directly. Also removes the debug diagnostics (no longer needed) and greps for `phpinfo` instead of `PHP Version`.

## Test plan

- [ ] All 27 smoke tests pass
- [ ] Image pushes to Quay.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)