### PR TITLE
fix: dispatch image-updated cascade to spanish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CRUNCHTOOLS_DISPATCH_TOKEN }}
         run: |
-          for repo in ubi10-httpd-php-mariadb ubi10-httpd-php-postgres; do
+          for repo in ubi10-httpd-php-mariadb ubi10-httpd-php-postgres spanish; do
             gh api repos/crunchtools/$repo/dispatches \
               -f event_type=parent-image-updated || true
           done


### PR DESCRIPTION
spanish is FROM quay.io/crunchtools/ubi10-httpd-php but was missing from this repo's dispatch list. Add it to the for-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)